### PR TITLE
Added support for FluentIterable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.fasterxml</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>7-SNAPSHOT</version>
+    <version>7</version>
   </parent>
   <groupId>com.fasterxml.jackson.datatype</groupId>
   <artifactId>jackson-datatype-guava</artifactId>
@@ -59,7 +59,7 @@ com.fasterxml.jackson.databind.type
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <!-- Guava has the weirdest versioning system... r11 is the current as of May 2012 -->
-      <version>11.0.2</version>
+      <version>12.0</version>
     </dependency>
 
      <!-- and for testing, JUnit is needed -->

--- a/src/main/java/com/fasterxml/jackson/datatype/guava/FluentIterableTypeModifier.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/FluentIterableTypeModifier.java
@@ -1,0 +1,26 @@
+package com.fasterxml.jackson.datatype.guava;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeBindings;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.type.TypeModifier;
+import com.google.common.collect.FluentIterable;
+
+import java.lang.reflect.Type;
+
+/**
+ * Guava 12 changed the implementation of their {@link FluentIterable} to include a method named "isEmpty."  This method
+ * causes Jackson to treat FluentIterables as a Bean instead of an {@link Iterable}.  Serialization of FluentIterables by
+ * default result in a string like "{\"empty\":true}."  This module modifies the JavaType of FluentIterable to be
+ * the same as Iterable.
+ */
+public class FluentIterableTypeModifier extends TypeModifier {
+    @Override
+    public JavaType modifyType(JavaType type, Type jdkType, TypeBindings context, TypeFactory typeFactory) {
+        if (FluentIterable.class.isAssignableFrom(type.getRawClass())) {
+            return typeFactory.constructType(Iterable.class, context);
+        }
+
+        return type;
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaModule.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaModule.java
@@ -22,6 +22,7 @@ public class GuavaModule extends Module // can't use just SimpleModule, due to g
         context.addDeserializers(new GuavaDeserializers());
         context.addSerializers(new GuavaSerializers());
         context.addTypeModifier(new MultimapTypeModifier());
+        context.addTypeModifier(new FluentIterableTypeModifier());
         context.addBeanSerializerModifier(new GuavaBeanSerializerModifier());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/guava/TestFluentIterable.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/guava/TestFluentIterable.java
@@ -1,0 +1,52 @@
+package com.fasterxml.jackson.datatype.guava;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests to verify serialization of {@link FluentIterable}s.
+ */
+public class TestFluentIterable extends BaseTest
+{
+    private final ObjectMapper MAPPER = mapperWithModule();
+
+
+    FluentIterable<Integer> createFluentIterable() {
+        return new FluentIterable<Integer>() {
+            private final Iterable<Integer> _iterable = Sets.newHashSet(1, 2, 3);
+            @Override
+            public Iterator<Integer> iterator() {
+                return _iterable.iterator();
+            }
+        };
+    }
+
+    /**
+     * This test is present so that we know if either Jackson's handling of FluentIterable
+     * or Guava's implementation of FluentIterable changes.
+     * @throws Exception
+     */
+    public void testSerializationWithoutModule() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        Iterable<Integer> fluentIterable = createFluentIterable();
+
+        String json = mapper.writeValueAsString(fluentIterable);
+
+        assertEquals("{\"empty\":false}", json);
+    }
+
+    public void testSerialization() throws Exception {
+        Iterable<Integer> fluentIterable = createFluentIterable();
+
+        String json = MAPPER.writeValueAsString(fluentIterable);
+
+        assertEquals("[1,2,3]", json);
+    }
+
+}


### PR DESCRIPTION
In Guava 12, FluentIterable, the returned type of such methods as Iterables.transform is serialized by Jackson as a Bean instead of an Iterable.  This commit modifies the type to be an Iterable again.
