### PR TITLE
add hashCode and equals to Module.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaModule.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaModule.java
@@ -24,4 +24,16 @@ public class GuavaModule extends Module // can't use just SimpleModule, due to g
         context.addTypeModifier(new GuavaTypeModifier());
         context.addBeanSerializerModifier(new GuavaBeanSerializerModifier());
     }
+
+    @Override
+    public int hashCode()
+    {
+        return GuavaModule.class.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        return this == o;
+    }
 }


### PR DESCRIPTION
This ensures that a set which collects modules only contains one
instance of the GuavaModule.
