### PR TITLE
Bump guava version to 15.0 (released 2013-09-06)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,7 @@ com.fasterxml.jackson.databind.type
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <!-- Guava has the weirdest versioning system... r11 is the current as of May 2012 -->
-      <version>14.0.1</version>
+      <version>15.0</version>
     </dependency>
 
      <!-- and for testing, JUnit is needed -->


### PR DESCRIPTION
I'm trying to consolidate guava versions across our dependencies, and it would be handy if jackson-datatype-guava depended on 15.0
