### PR TITLE
add support for Guava 10 through 13 to the Range deserializer

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeDeserializer.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.datatype.guava.deser;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.datatype.guava.deser.util.RangeFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
@@ -34,7 +35,7 @@ public class RangeDeserializer
 
     /*
     /**********************************************************
-    /* Life-cyecl
+    /* Life-cycle
     /**********************************************************
      */
     
@@ -133,23 +134,24 @@ public class RangeDeserializer
                                          upperEndpoint.getClass().getName());
                 Preconditions.checkState(lowerBoundType != null, "'lowerEndpoint' field found, but not 'lowerBoundType'");
                 Preconditions.checkState(upperBoundType != null, "'upperEndpoint' field found, but not 'upperBoundType'");
-                return Range.range(lowerEndpoint, lowerBoundType, upperEndpoint, upperBoundType);
+                return RangeFactory.range(lowerEndpoint, lowerBoundType, upperEndpoint, upperBoundType);
             }
             if (lowerEndpoint != null) {
                 Preconditions.checkState(lowerBoundType != null, "'lowerEndpoint' field found, but not 'lowerBoundType'");
-                return Range.downTo(lowerEndpoint, lowerBoundType);
+                return RangeFactory.downTo(lowerEndpoint, lowerBoundType);
             }
             if (upperEndpoint != null) {
                 Preconditions.checkState(upperBoundType != null, "'upperEndpoint' field found, but not 'upperBoundType'");
-                return Range.upTo(upperEndpoint, upperBoundType);
+                return RangeFactory.upTo(upperEndpoint, upperBoundType);
             }
-            return Range.all();
+            return RangeFactory.all();
         } catch (IllegalStateException e) {
             throw new JsonMappingException(e.getMessage());
         }
     }
 
-    private BoundType deserializeBoundType(JsonParser parser) throws IOException {
+    private BoundType deserializeBoundType(JsonParser parser) throws IOException
+    {
         expect(parser, JsonToken.VALUE_STRING, parser.getCurrentToken());
         String name = parser.getText();
         try {

--- a/src/main/java/com/fasterxml/jackson/datatype/guava/deser/util/RangeFactory.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/deser/util/RangeFactory.java
@@ -1,0 +1,177 @@
+
+package com.fasterxml.jackson.datatype.guava.deser.util;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
+
+/**
+ * A factory for creating Guava {@link Range}s that is compatible with Guava 10 and later.
+ *
+ * If Guava 10, 11, 12, or 13 is being used, the factory methods in the com.google.common.collect.Ranges class (a beta
+ * class that was removed in Guava 14) are used to reflectively instantiate Ranges. If Guava 14 or later is being used,
+ * the factory methods in the Range class itself (added in Guava 14) are used to instantiate Ranges.
+ */
+public class RangeFactory
+{
+    private static final String LEGACY_RANGES_CLASS_NAME = "com.google.common.collect.Ranges";
+
+    private static final String LEGACY_RANGE_METHOD_NAME = "range";
+    private static final String LEGACY_DOWN_TO_METHOD_NAME = "downTo";
+    private static final String LEGACY_UP_TO_METHOD_NAME = "upTo";
+    private static final String LEGACY_ALL_METHOD_NAME = "all";
+
+    private static Method legacyRangeMethod;
+    private static Method legacyDownToMethod;
+    private static Method legacyUpToMethod;
+    private static Method legacyAllMethod;
+
+    static
+    {
+        initLegacyRangeFactoryMethods();
+    }
+
+    private static void initLegacyRangeFactoryMethods()
+    {
+        try {
+            Class rangesClass = Class.forName(LEGACY_RANGES_CLASS_NAME);
+            legacyRangeMethod = findMethod(rangesClass, LEGACY_RANGE_METHOD_NAME, Comparable.class, BoundType.class,
+                                           Comparable.class, BoundType.class);
+            legacyDownToMethod = findMethod(rangesClass, LEGACY_DOWN_TO_METHOD_NAME, Comparable.class, BoundType.class);
+            legacyUpToMethod = findMethod(rangesClass, LEGACY_UP_TO_METHOD_NAME, Comparable.class, BoundType.class);
+            legacyAllMethod = findMethod(rangesClass, LEGACY_ALL_METHOD_NAME);
+        } catch (ClassNotFoundException e) {
+            // ignore
+        }
+    }
+
+    // returns null if the method is not found
+    private static Method findMethod(Class<?> clazz, String methodName, Class ... paramTypes)
+    {
+        try {
+            return clazz.getMethod(methodName, paramTypes);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
+
+    public static <C extends Comparable<?>> Range<C> open(C lowerEndpoint, C upperEndpoint)
+    {
+        return range(lowerEndpoint, BoundType.OPEN, upperEndpoint, BoundType.OPEN);
+    }
+
+    public static <C extends Comparable<?>> Range<C> openClosed(C lowerEndpoint, C upperEndpoint)
+    {
+        return range(lowerEndpoint, BoundType.OPEN, upperEndpoint, BoundType.CLOSED);
+    }
+
+    public static <C extends Comparable<?>> Range<C> closedOpen(C lowerEndpoint, C upperEndpoint)
+    {
+        return range(lowerEndpoint, BoundType.CLOSED, upperEndpoint, BoundType.OPEN);
+    }
+
+    public static <C extends Comparable<?>> Range<C> closed(C lowerEndpoint, C upperEndpoint)
+    {
+        return range(lowerEndpoint, BoundType.CLOSED, upperEndpoint, BoundType.CLOSED);
+    }
+
+    public static <C extends Comparable<?>> Range<C> range(final C lowerEndpoint, final BoundType lowerBoundType,
+                           final C upperEndpoint, final BoundType upperBoundType)
+    {
+        return createRange(new Callable<Range<C>>() {
+            public Range<C> call() throws Exception {
+                return Range.range(lowerEndpoint, lowerBoundType, upperEndpoint, upperBoundType);
+            }
+        }, legacyRangeMethod, lowerEndpoint, lowerBoundType, upperEndpoint, upperBoundType);
+    }
+
+    public static <C extends Comparable<?>> Range<C> greaterThan(C lowerEndpoint)
+    {
+        return downTo(lowerEndpoint, BoundType.OPEN);
+    }
+
+    public static <C extends Comparable<?>> Range<C> atLeast(C lowerEndpoint)
+    {
+        return downTo(lowerEndpoint, BoundType.CLOSED);
+    }
+
+    public static <C extends Comparable<?>> Range<C> downTo(final C lowerEndpoint, final BoundType lowerBoundType)
+    {
+        return createRange(new Callable<Range<C>>() {
+            public Range<C> call() throws Exception {
+                return Range.downTo(lowerEndpoint, lowerBoundType);
+            }
+        }, legacyDownToMethod, lowerEndpoint, lowerBoundType);
+    }
+
+    public static <C extends Comparable<?>> Range<C> lessThan(C upperEndpoint)
+    {
+        return upTo(upperEndpoint, BoundType.OPEN);
+    }
+
+    public static <C extends Comparable<?>> Range<C> atMost(C upperEndpoint)
+    {
+        return upTo(upperEndpoint, BoundType.CLOSED);
+    }
+
+    public static <C extends Comparable<?>> Range<C> upTo(final C upperEndpoint, final BoundType upperBoundType)
+    {
+        return createRange(new Callable<Range<C>>() {
+            public Range<C> call() throws Exception {
+                return Range.upTo(upperEndpoint, upperBoundType);
+            }
+        }, legacyUpToMethod, upperEndpoint, upperBoundType);
+    }
+
+    public static <C extends Comparable<?>> Range<C> all()
+    {
+        return createRange(new Callable<Range<C>>() {
+            public Range<C> call() throws Exception {
+                return Range.all();
+            }
+        }, legacyAllMethod);
+    }
+
+    public static <C extends Comparable<?>> Range<C> singleton(final C value)
+    {
+        return createRange(new Callable<Range<C>>() {
+            public Range<C> call() throws Exception {
+                return Range.singleton(value);
+            }
+        }, legacyRangeMethod, value, BoundType.CLOSED, value, BoundType.CLOSED);
+    }
+
+    private static <C extends Comparable<?>> Range<C> createRange(Callable<Range<C>> rangeCallable, Method legacyRangeFactoryMethod, Object ... params)
+    {
+        try {
+            return rangeCallable.call();
+        } catch (NoSuchMethodError noSuchMethodError) {
+            if (legacyRangeFactoryMethod != null) {
+                return invokeLegacyRangeFactoryMethod(legacyRangeFactoryMethod, params);
+            } else {
+                throw noSuchMethodError;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <C extends Comparable<?>> Range<C> invokeLegacyRangeFactoryMethod(Method method, Object... params)
+    {
+        try {
+            //noinspection unchecked
+            return (Range<C>) method.invoke(null, params);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to invoke legacy Range factory method [" + method.getName() +
+                                               "] with params " + Lists.newArrayList(params) + ".", e);
+        }
+    }
+
+    // prevent instantiation
+    private RangeFactory()
+    {
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/guava/TestRange.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/guava/TestRange.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.datatype.guava;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.deser.util.RangeFactory;
 import com.google.common.base.Objects;
 import com.google.common.collect.Range;
 
@@ -28,29 +29,31 @@ public class TestRange extends BaseTest {
      * or Guava's implementation of Range changes.
      * @throws Exception
      */
-    public void testSerializationWithoutModule() throws Exception {
+    public void testSerializationWithoutModule() throws Exception
+    {
         ObjectMapper mapper = new ObjectMapper();
-        Range<Integer> range = Range.closed(1, 10);
+        Range<Integer> range = RangeFactory.closed(1, 10);
         String json = mapper.writeValueAsString(range);
         assertEquals("{\"empty\":false}", json);
     }
 
     public void testSerialization() throws Exception
     {
-        testSerialization(MAPPER, Range.open(1, 10));
-        testSerialization(MAPPER, Range.openClosed(1, 10));
-        testSerialization(MAPPER, Range.closedOpen(1, 10));
-        testSerialization(MAPPER, Range.closed(1, 10));
-        testSerialization(MAPPER, Range.atLeast(1));
-        testSerialization(MAPPER, Range.greaterThan(1));
-        testSerialization(MAPPER, Range.atMost(10));
-        testSerialization(MAPPER, Range.lessThan(10));
-        testSerialization(MAPPER, Range.all());
+        testSerialization(MAPPER, RangeFactory.open(1, 10));
+        testSerialization(MAPPER, RangeFactory.openClosed(1, 10));
+        testSerialization(MAPPER, RangeFactory.closedOpen(1, 10));
+        testSerialization(MAPPER, RangeFactory.closed(1, 10));
+        testSerialization(MAPPER, RangeFactory.atLeast(1));
+        testSerialization(MAPPER, RangeFactory.greaterThan(1));
+        testSerialization(MAPPER, RangeFactory.atMost(10));
+        testSerialization(MAPPER, RangeFactory.lessThan(10));
+        testSerialization(MAPPER, RangeFactory.all());
+        testSerialization(MAPPER, RangeFactory.singleton(1));
     }
 
     public void testDeserialization() throws Exception
     {
-        String json = MAPPER.writeValueAsString(Range.open(1, 10));
+        String json = MAPPER.writeValueAsString(RangeFactory.open(1, 10));
         @SuppressWarnings("unchecked")
         Range<Integer> r = (Range<Integer>) MAPPER.readValue(json, Range.class);
         assertNotNull(r);
@@ -58,7 +61,8 @@ public class TestRange extends BaseTest {
         assertEquals(Integer.valueOf(10), r.upperEndpoint());
     }
     
-    private void testSerialization(ObjectMapper objectMapper, Range<?> range) throws IOException {
+    private void testSerialization(ObjectMapper objectMapper, Range<?> range) throws IOException
+    {
         String json = objectMapper.writeValueAsString(range);
         Range<?> rangeClone = objectMapper.readValue(json, Range.class);
         assert Objects.equal(rangeClone, range);
@@ -66,7 +70,7 @@ public class TestRange extends BaseTest {
 
     public void testUntyped() throws Exception
     {
-        String json = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(new Untyped(Range.open(1, 10)));
+        String json = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(new Untyped(RangeFactory.open(1, 10)));
         Untyped out = MAPPER.readValue(json, Untyped.class);
         assertNotNull(out);
         assertEquals(Range.class, out.range.getClass());


### PR DESCRIPTION
Guava 10 through 13 required using the com.google.common.collect.Ranges utility class (removed in Guava 14) to instantiate Ranges. Since these versions of Guava are not that old (the product I work on is using Guava 13), I think it makes sense for the Range deserializer to support them.
