### PR TITLE
Fix NullPointerException when Integer deserializer returns null

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/guava/deser/GuavaOptionalDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/deser/GuavaOptionalDeserializer.java
@@ -99,7 +99,7 @@ public class GuavaOptionalDeserializer
         } else {
             refd = _valueDeserializer.deserializeWithType(jp, ctxt, _valueTypeDeserializer);
         }
-        return Optional.of(refd);
+        return Optional.fromNullable(refd);
     }
 
     /* NOTE: usually should not need this method... but for some reason, it is needed here.
@@ -121,6 +121,6 @@ public class GuavaOptionalDeserializer
             return deserialize(jp, ctxt);
         }
         // with type deserializer to use here? Looks like we get passed same one?
-        return Optional.of(typeDeserializer.deserializeTypedFromAny(jp, ctxt));
+        return Optional.fromNullable(typeDeserializer.deserializeTypedFromAny(jp, ctxt));
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/guava/TestOptional.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/guava/TestOptional.java
@@ -77,7 +77,12 @@ public class TestOptional extends ModuleTestBase
         assertTrue(data.get().myData.isPresent());
         assertEquals("simpleString", data.get().myData.get());
     }
-    
+
+    public void testDeserNull() throws Exception {
+        Optional<?> value = MAPPER.readValue("\"\"", new TypeReference<Optional<Integer>>() {});
+        assertFalse(value.isPresent());
+    }
+
     public void testSerAbsent() throws Exception {
         String value = MAPPER.writeValueAsString(Optional.absent());
         assertEquals("null", value);


### PR DESCRIPTION
This pull requests reproduces and fixes a NullPointerException when using GuavaOptional with a deserialized value of null.
The added unit test in the pull request simulates my use case in which data is read from a CSV file to an ObjectNode that contains strings, and from there it is read into an Object that assigns the string to Optional<Integer> field. The Integer deserializer returns null, and the GuavaOptional deserializer should convert that in Optional.absent(). Instead a NPE is thrown.