### PR TITLE
Guava collection types do not allow null values

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/guava/deser/GuavaImmutableMapDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/deser/GuavaImmutableMapDeserializer.java
@@ -45,7 +45,9 @@ abstract class GuavaImmutableMapDeserializer<T extends ImmutableMap<Object, Obje
             } else {
                 value = valueDes.deserializeWithType(jp, ctxt, typeDeser);
             }
-            builder.put(key, value);
+            if (null != value) {
+                builder.put(key, value);
+            }
         }
         // No class outside of the package will be able to subclass us,
         // and we provide the proper builder for the subclasses we implement.


### PR DESCRIPTION
ImmutableMap (and other types) do not allow null values.  Trying to store nulls will result in a `java.lang.NullPointerException`.  Can we simply eliminate storing nulls?  If this PR acceptable, I can make similar changes for other types as well.