### PR TITLE
Add HashCode (de)serialization support.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.datatype.guava;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.*;
+import com.google.common.hash.HashCode;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.InternetDomainName;
 
@@ -236,6 +237,9 @@ public class GuavaDeserializers
         }
         if (raw == InternetDomainName.class) {
             return InternetDomainNameDeserializer.std;
+        }
+        if (raw == HashCode.class) {
+            return HashCodeDeserializer.std;
         }
         return super.findBeanDeserializer(type, config, beanDesc);
     }

--- a/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaSerializers.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaSerializers.java
@@ -5,6 +5,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheBuilderSpec;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
+import com.google.common.hash.HashCode;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.InternetDomainName;
 import com.fasterxml.jackson.databind.*;
@@ -38,6 +39,9 @@ public class GuavaSerializers extends Serializers.Base
         }
         // not sure how useful, but why not?
         if (CacheBuilderSpec.class.isAssignableFrom(raw) || CacheBuilder.class.isAssignableFrom(raw)) {
+            return ToStringSerializer.instance;
+        }
+        if (HashCode.class.isAssignableFrom(raw)) {
             return ToStringSerializer.instance;
         }
         return super.findSerializer(config, type, beanDesc);

--- a/src/main/java/com/fasterxml/jackson/datatype/guava/deser/HashCodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/deser/HashCodeDeserializer.java
@@ -1,0 +1,22 @@
+package com.fasterxml.jackson.datatype.guava.deser;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
+import com.google.common.hash.HashCode;
+
+public class HashCodeDeserializer extends FromStringDeserializer<HashCode>
+{
+    private static final long serialVersionUID = 1L;
+
+    public final static HashCodeDeserializer std = new HashCodeDeserializer();
+
+    public HashCodeDeserializer() { super(HashCode.class); }
+
+    @Override
+    protected HashCode _deserialize(String value, DeserializationContext ctxt)
+            throws IOException {
+        return HashCode.fromString(value);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/guava/HashCodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/guava/HashCodeTest.java
@@ -1,0 +1,32 @@
+package com.fasterxml.jackson.datatype.guava;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.hash.HashCode;
+
+public class HashCodeTest extends ModuleTestBase
+{
+    private final ObjectMapper MAPPER = mapperWithModule();
+
+    public void testSerialization() throws Exception
+    {
+        HashCode input = HashCode.fromString("cafebabe12345678");
+        String json = MAPPER.writeValueAsString(input);
+        assertEquals("\"cafebabe12345678\"", json);
+    }
+
+    public void testDeserialization() throws Exception
+    {
+        // success:
+        HashCode result = MAPPER.readValue(quote("12345678cafebabe"), HashCode.class);
+        assertEquals("12345678cafebabe", result.toString());
+
+        // and ... error (note: numbers, booleans may all be fine)
+        try {
+            result = MAPPER.readValue("[ ]", HashCode.class);
+            fail("Should not deserialize from boolean: got "+result);
+        } catch (JsonProcessingException e) {
+            verifyException(e, "Can not deserialize");
+        }
+    }
+}


### PR DESCRIPTION
The logic implemented here is derived from the `HostAndPort` (de)serialization code. As it stands, serialization produces lower case hash code strings and deserialization accepts _only_ lower case hash code strings.

Perhaps we should call `String.toLowerCase(Locale.ENGLISH)` prior to deserialization, so as to support upper and mixed cased strings. That does come with a minor performance penalty, of course. Thoughts?
