### PR TITLE
*Really* accept mixed-case hash codes.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/guava/deser/HashCodeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/deser/HashCodeDeserializer.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.datatype.guava.deser;
 
 import java.io.IOException;
+import java.util.Locale;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
@@ -17,6 +18,6 @@ public class HashCodeDeserializer extends FromStringDeserializer<HashCode>
     @Override
     protected HashCode _deserialize(String value, DeserializationContext ctxt)
             throws IOException {
-        return HashCode.fromString(value);
+        return HashCode.fromString(value.toLowerCase(Locale.ENGLISH));
     }
 }

--- a/src/test/java/com/fasterxml/jackson/datatype/guava/HashCodeTest.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/guava/HashCodeTest.java
@@ -18,15 +18,15 @@ public class HashCodeTest extends ModuleTestBase
     public void testDeserialization() throws Exception
     {
         // success:
-        HashCode result = MAPPER.readValue(quote("12345678cafebabe"), HashCode.class);
-        assertEquals("12345678cafebabe", result.toString());
+        HashCode result = MAPPER.readValue(quote("0123456789cAfEbAbE"), HashCode.class);
+        assertEquals("0123456789cafebabe", result.toString());
 
-        // and ... error (note: numbers, booleans may all be fine)
+        // and ... error:
         try {
-            result = MAPPER.readValue("[ ]", HashCode.class);
-            fail("Should not deserialize from boolean: got "+result);
+            result = MAPPER.readValue(quote("ghijklmn0123456789"), HashCode.class);
+            fail("Should not deserialize from non-hex string: got "+result);
         } catch (JsonProcessingException e) {
-            verifyException(e, "Can not deserialize");
+            verifyException(e, "Illegal hexadecimal character");
         }
     }
 }


### PR DESCRIPTION
This change should have been part of f234cc891d6badb787be9922dad51e9a235b154c,
but somehow was never committed.

(I have a hard time explaining how we overlooked this...)
