### PR TITLE
Add com.google.common.hash to import list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@ ${project.groupId}.guava.*;version=${project.version}
 com.google.common.collect,
 com.google.common.base,
 com.google.common.cache,
+com.google.common.hash,
 com.google.common.net,
 com.fasterxml.jackson.core,
 com.fasterxml.jackson.core.util,


### PR DESCRIPTION
com.google.common.hash is used by GuavaSerializers.  Without this import, serialization will throw an exception when run as a OSGi bundle.