### PR TITLE
Add deserialization support for SortedMultiset and ImmutableSortedMultiset

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/guava/deser/ImmutableSortedMultisetDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/deser/ImmutableSortedMultisetDeserializer.java
@@ -1,0 +1,30 @@
+package com.fasterxml.jackson.datatype.guava.deser;
+
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.google.common.collect.ImmutableCollection.Builder;
+import com.google.common.collect.ImmutableSortedMultiset;
+
+public class ImmutableSortedMultisetDeserializer extends GuavaImmutableCollectionDeserializer<ImmutableSortedMultiset<Object>>
+{
+    private static final long serialVersionUID = 1L;
+
+    public ImmutableSortedMultisetDeserializer(CollectionType type, TypeDeserializer typeDeser, JsonDeserializer<?> deser) {
+        super(type, typeDeser, deser);
+    }
+
+    @Override
+    protected Builder<Object> createBuilder() {
+        /* This is suboptimal. See the considerations in ImmutableSortedSetDeserializer. */
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        Builder<Object> builder =  (Builder) ImmutableSortedMultiset.naturalOrder();
+        return builder;
+    }
+
+    @Override
+    public GuavaCollectionDeserializer<ImmutableSortedMultiset<Object>> withResolved(TypeDeserializer typeDeser,
+            JsonDeserializer<?> valueDeser) {
+        return new ImmutableSortedMultisetDeserializer(_containerType, typeDeser, valueDeser);
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultisets.java
+++ b/src/test/java/com/fasterxml/jackson/datatype/guava/TestMultisets.java
@@ -56,7 +56,7 @@ public class TestMultisets extends ModuleTestBase
 
     final ObjectMapper MAPPER = mapperWithModule();
     
-    public void testDefault() throws Exception
+    public void testDefaultMultiset() throws Exception
     {
         Multiset<String> set = MAPPER.readValue("[\"abc\",\"abc\",\"foo\"]", new TypeReference<Multiset<String>>() { });
         assertEquals(3, set.size());
@@ -65,6 +65,14 @@ public class TestMultisets extends ModuleTestBase
         assertEquals(0, set.count("bar"));
     }
     
+    public void testDefaultSortedMultiset() throws Exception {
+        SortedMultiset<String> set = MAPPER.readValue("[\"abc\",\"abc\",\"foo\"]", new TypeReference<SortedMultiset<String>>() { });
+        assertEquals(3, set.size());
+        assertEquals(1, set.count("foo"));
+        assertEquals(2, set.count("abc"));
+        assertEquals(0, set.count("bar"));
+    }
+
     public void testLinkedHashMultiset() throws Exception {
         LinkedHashMultiset<String> set = MAPPER.readValue("[\"abc\",\"abc\",\"foo\"]", new TypeReference<LinkedHashMultiset<String>>() { });
         assertEquals(3, set.size());
@@ -91,6 +99,14 @@ public class TestMultisets extends ModuleTestBase
     
     public void testImmutableMultiset() throws Exception {
         ImmutableMultiset<String> set = MAPPER.readValue("[\"abc\",\"abc\",\"foo\"]", new TypeReference<ImmutableMultiset<String>>() { });
+        assertEquals(3, set.size());
+        assertEquals(1, set.count("foo"));
+        assertEquals(2, set.count("abc"));
+        assertEquals(0, set.count("bar"));
+    }
+
+    public void testImmutableSortedMultiset() throws Exception {
+        ImmutableSortedMultiset<String> set = MAPPER.readValue("[\"abc\",\"abc\",\"foo\"]", new TypeReference<ImmutableSortedMultiset<String>>() { });
         assertEquals(3, set.size());
         assertEquals(1, set.count("foo"));
         assertEquals(2, set.count("abc"));


### PR DESCRIPTION
While there, fix the message of the exception thrown when one attempts to deserialize an `ImmutableSortedSet`: previously the target collection type was mentioned twice, while we now report the offending element type.