### PR TITLE
Bring back Java 6 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,6 @@ Guava (http://code.google.com/p/guava-libraries/) types (currently mostly just c
   <properties>
     <version.jackson>2.6.0-rc3</version.jackson>
 
-    <!-- More modern guava versions require 1.7? -->
-    <javac.src.version>1.7</javac.src.version>
-    <javac.target.version>1.7</javac.target.version>
-
     <version.guava>15.0</version.guava>
     <version.guava.osgi>${version.guava}.0</version.guava.osgi>
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -16,7 +16,6 @@ Project: jackson-datatype-guava
 #69: Add support for `JsonInclude.Include.NON_ABSENT`, to compensate for #66
 #70: Change OSGi manifest entries to import guava 15.0 or greater
  (reported by sprynter@github)
-- Upgrade JDK baseline to 1.7
 
 2.5.4 (09-Jun-2015)
 


### PR DESCRIPTION
I noticed Java 6 support was dropped in 2.6.0-rc3 (b83c00e7ac5a4bd27b1508d119a6fb737fe35660).  This seems unnecessary, as latest guava still supports Java 6 (see https://github.com/google/guava#guava-google-core-libraries-for-java).  Thanks.