### PR TITLE
New configuration for Guava Range default bound type.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaDeserializers.java
@@ -25,6 +25,12 @@ import com.fasterxml.jackson.datatype.guava.deser.multimap.set.LinkedHashMultima
 public class GuavaDeserializers
     extends Deserializers.Base
 {
+    private BoundType _defaultBoundType;
+
+    public GuavaDeserializers(BoundType defaultBoundType) {
+        _defaultBoundType = defaultBoundType;
+    }
+
     /**
      * We have plenty of collection types to support...
      */
@@ -251,7 +257,7 @@ public class GuavaDeserializers
             return new GuavaOptionalDeserializer(type, refType, typeDeser, valueDeser);
         }
         if (raw == Range.class) {
-            return new RangeDeserializer(type);
+            return new RangeDeserializer(_defaultBoundType, type);
         }
         if (raw == HostAndPort.class) {
             return HostAndPortDeserializer.std;

--- a/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaModule.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/GuavaModule.java
@@ -3,7 +3,11 @@ package com.fasterxml.jackson.datatype.guava;
 import com.fasterxml.jackson.core.Version;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.cfg.PackageVersion;
 import com.fasterxml.jackson.datatype.guava.ser.GuavaBeanSerializerModifier;
+import com.google.common.collect.BoundType;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Basic Jackson {@link Module} that adds support for Guava types.
@@ -37,6 +41,7 @@ public class GuavaModule extends Module // can't use just SimpleModule, due to g
      * changes after registration will have no effect.
      */
     protected boolean _cfgHandleAbsentAsNull = true;
+    protected BoundType _defaultBoundType;
     
     public GuavaModule() {
         super();
@@ -48,7 +53,7 @@ public class GuavaModule extends Module // can't use just SimpleModule, due to g
     @Override
     public void setupModule(SetupContext context)
     {
-        context.addDeserializers(new GuavaDeserializers());
+        context.addDeserializers(new GuavaDeserializers(_defaultBoundType));
         context.addSerializers(new GuavaSerializers());
         context.addTypeModifier(new GuavaTypeModifier());
 
@@ -73,6 +78,24 @@ public class GuavaModule extends Module // can't use just SimpleModule, due to g
      */
     public GuavaModule configureAbsentsAsNulls(boolean state) {
         _cfgHandleAbsentAsNull = state;
+        return this;
+    }
+
+    /**
+     * Configuration method that may be used to change the {@link BoundType} to be used
+     * when deserializing {@link com.google.common.collect.Range} objects. This configuration
+     * will is used when the object to be deserialied has no bound type attribute.
+     * The default {@link BoundType} is CLOSED.
+     *
+     * @param boundType {@link BoundType}
+     *
+     * @return This module instance, useful for chaining calls
+     *
+     * @since 2.6.1 ? FIXME
+     */
+    public GuavaModule defaultBoundType(BoundType boundType) {
+        checkNotNull(boundType);
+        _defaultBoundType = boundType;
         return this;
     }
     

--- a/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/datatype/guava/deser/RangeDeserializer.java
@@ -33,14 +33,17 @@ public class RangeDeserializer
 
     protected final JsonDeserializer<Object> _endpointDeserializer;
 
+    private BoundType _defaultBoundType;
+
     /*
     /**********************************************************
     /* Life-cycle
     /**********************************************************
      */
     
-    public RangeDeserializer(JavaType rangeType) {
+    public RangeDeserializer(BoundType defaultBoundType, JavaType rangeType) {
         this(rangeType, null);
+        this._defaultBoundType = defaultBoundType;
     }
 
     @SuppressWarnings("unchecked")
@@ -49,6 +52,15 @@ public class RangeDeserializer
         super(rangeType);
         _rangeType = rangeType;
         _endpointDeserializer = (JsonDeserializer<Object>) endpointDeser;
+    }
+
+    @SuppressWarnings("unchecked")
+    public RangeDeserializer(JavaType rangeType, JsonDeserializer<?> endpointDeser, BoundType defaultBoundType)
+    {
+        super(rangeType);
+        _rangeType = rangeType;
+        _endpointDeserializer = (JsonDeserializer<Object>) endpointDeser;
+        _defaultBoundType = defaultBoundType;
     }
 
     @Override
@@ -64,7 +76,7 @@ public class RangeDeserializer
                 endpointType = TypeFactory.unknownType();
             }
             JsonDeserializer<Object> deser = ctxt.findContextualValueDeserializer(endpointType, property);
-            return new RangeDeserializer(_rangeType, deser);
+            return new RangeDeserializer(_rangeType, deser, _defaultBoundType);
         }
         return this;
     }
@@ -125,6 +137,12 @@ public class RangeDeserializer
                 throw new JsonMappingException(e.getMessage());
             }
         }
+
+        if (lowerBoundType == null)
+            lowerBoundType = _defaultBoundType;
+
+        if (upperBoundType == null)
+            upperBoundType = _defaultBoundType;
 
         try {
             if ((lowerEndpoint != null) && (upperEndpoint != null)) {


### PR DESCRIPTION
Now it's possible do set a default bound type for Guava Range objects.
The intent of this is to get the JSON deserialized without informing the bound types every time even when wanted to use the same one for all objects.
The configured default bound type is passed to the deserializer by constructor method.
If the JSON object has no bound type and there's no default configured, we still get the exception.
I added some test cases with and without default bound type configured.