### PR TITLE
Relax the version constraint on guava.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,10 @@ Guava (http://code.google.com/p/guava-libraries/) types (currently mostly just c
 ${project.groupId}.guava.*;version=${project.version}
       </osgi.export>
       <osgi.import>
-com.google.common.collect,
-com.google.common.base,
-com.google.common.cache,
-com.google.common.net,
+com.google.common.collect;version="[15.0.0,20)",
+com.google.common.base;version="[15.0.0,20)",
+com.google.common.cache;version="[15.0.0,20)",
+com.google.common.net;version="[15.0.0,20)",
 com.fasterxml.jackson.core,
 com.fasterxml.jackson.core.util,
 com.fasterxml.jackson.databind,


### PR DESCRIPTION
The OSGi metadata marks this as requiring Guava from [15.0,15.1). So it doesn't work with newer guavas.

To solve this, we either need many different artifacts with different class names, or we need to be brave and imagine that the Guava people don't make many incompatible changes to the classes it support. I tested it with Guava 18.

Addresses issue #81.
