### PR TITLE
Updating OSGi Import section 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,7 @@ Guava (http://code.google.com/p/guava-libraries/) types (currently mostly just c
         -->
     <osgi.import>
 com.google.common.*;version="${version.guava.osgi}",
-com.fasterxml.jackson.annotation.*;version="${version.jackson.annotations}",
-com.fasterxml.jackson.core.*;version="${version.jackson.core}",
-com.fasterxml.jackson.databind.*;version="${version.jackson.core}"
+*
     </osgi.import>
   </properties>
 


### PR DESCRIPTION
This solution seems to be equivalent to what the default behavior gives -- version ranges [2.7,3) -- except with the added guava version specifier. It seems consistent with the way datatype-joda's manifest looks, and it should work fine as long as you expect jackson versioning to be consistent with Semantic Versioning.
